### PR TITLE
Fixing minor issues

### DIFF
--- a/ietf-flexi-grid-topology.yang
+++ b/ietf-flexi-grid-topology.yang
@@ -1,7 +1,7 @@
 module ietf-flexi-grid-topology {
   yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-flexi-grid-topology";
-  prefix "flexi-grid";
+  prefix "tet-flexig";
 
   import ietf-network {
     prefix "nw";
@@ -101,7 +101,7 @@ module ietf-flexi-grid-topology {
   augment "/nw:networks/nw:network/nw:node/tet:te"
         + "/tet:te-node-attributes" {
     when "/nw:networks/nw:network/nw:network-types"
-       + "/tet:te-topology/flexi-grid:flexi-grid-topology" {
+       + "/tet:te-topology/tet-flexig:flexi-grid-topology" {
       description
       "Augmentation parameters apply only for networks with
        Flexi-grid topology type.";
@@ -121,7 +121,7 @@ module ietf-flexi-grid-topology {
         + "tet:te-node-attributes/tet:connectivity-matrices/"
         + "tet:label-restrictions/tet:label-restriction" {
     when "../../../../../../nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -137,7 +137,7 @@ module ietf-flexi-grid-topology {
         + "tet:connectivity-matrix/tet:from/"
         + "tet:label-restrictions/tet:label-restriction" {
     when "../../../../../../../../nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -153,7 +153,7 @@ module ietf-flexi-grid-topology {
         + "tet:connectivity-matrix/tet:to/"
         + "tet:label-restrictions/tet:label-restriction" {
     when "../../../../../../../../nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -169,7 +169,7 @@ module ietf-flexi-grid-topology {
         + "tet:connectivity-matrices/tet:label-restrictions/"
         + "tet:label-restriction" {
     when "../../../../../../nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -185,7 +185,7 @@ module ietf-flexi-grid-topology {
         + "tet:connectivity-matrix/"
         + "tet:from/tet:label-restrictions/tet:label-restriction" {
     when "../../../../../../../../nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -201,7 +201,7 @@ module ietf-flexi-grid-topology {
         + "tet:connectivity-matrix/"
         + "tet:to/tet:label-restrictions/tet:label-restriction" {
     when "../../../../../../../../nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -217,7 +217,7 @@ module ietf-flexi-grid-topology {
         + "tet:local-link-connectivities/"
         + "tet:label-restrictions/tet:label-restriction" {
     when "../../../../../../nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -234,7 +234,7 @@ module ietf-flexi-grid-topology {
         + "tet:local-link-connectivity/"
         + "tet:label-restrictions/tet:label-restriction" {
     when "../../../../../../../nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -249,7 +249,7 @@ module ietf-flexi-grid-topology {
         + "tet:te-link-attributes/"
         + "tet:label-restrictions/tet:label-restriction" {
     when "../../../../../nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -263,7 +263,7 @@ module ietf-flexi-grid-topology {
         + "tet:information-source-entry/"
         + "tet:label-restrictions/tet:label-restriction" {
     when "../../../../../nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -292,7 +292,7 @@ module ietf-flexi-grid-topology {
         + "tet:label-start/"
         + "tet:te-label/tet:technology" {
     when "../../../../../../../../nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -311,7 +311,7 @@ module ietf-flexi-grid-topology {
         + "tet:label-restriction/tet:label-end/"
         + "tet:te-label/tet:technology" {
     when "../../../../../../../../nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -330,7 +330,7 @@ module ietf-flexi-grid-topology {
         + "tet:label-restriction/tet:label-step/"
         + "tet:technology" {
     when "../../../../../../../nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -350,7 +350,7 @@ module ietf-flexi-grid-topology {
         + "tet:te-label/tet:technology" {
     when "../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -370,7 +370,7 @@ module ietf-flexi-grid-topology {
         + "tet:te-label/tet:technology" {
     when "../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -393,7 +393,7 @@ module ietf-flexi-grid-topology {
         + "tet:te-label/tet:technology" {
     when "../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -417,7 +417,7 @@ module ietf-flexi-grid-topology {
         + "tet:te-label/tet:technology" {
     when "../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -438,7 +438,7 @@ module ietf-flexi-grid-topology {
         + "tet:te-label/tet:technology" {
     when "../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -459,7 +459,7 @@ module ietf-flexi-grid-topology {
         + "tet:te-label/tet:technology" {
     when "../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -480,7 +480,7 @@ module ietf-flexi-grid-topology {
         + "tet:te-label/tet:technology" {
     when "../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -501,7 +501,7 @@ module ietf-flexi-grid-topology {
         + "tet:technology" {
     when "../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -522,7 +522,7 @@ module ietf-flexi-grid-topology {
         + "tet:te-label/tet:technology" {
     when "../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -543,7 +543,7 @@ module ietf-flexi-grid-topology {
         + "tet:te-label/tet:technology" {
     when "../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -564,7 +564,7 @@ module ietf-flexi-grid-topology {
         + "tet:technology" {
     when "../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -585,7 +585,7 @@ module ietf-flexi-grid-topology {
         + "tet:te-label/tet:technology" {
     when "../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -606,7 +606,7 @@ module ietf-flexi-grid-topology {
         + "tet:te-label/tet:technology" {
     when "../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -628,7 +628,7 @@ module ietf-flexi-grid-topology {
         + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
     when "../../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -650,7 +650,7 @@ module ietf-flexi-grid-topology {
         + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
     when "../../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -671,7 +671,7 @@ module ietf-flexi-grid-topology {
         + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
     when "../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -691,7 +691,7 @@ module ietf-flexi-grid-topology {
         + "tet:label-start/tet:te-label/tet:technology" {
     when "../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -711,7 +711,7 @@ module ietf-flexi-grid-topology {
         + "tet:label-end/tet:te-label/tet:technology" {
     when "../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -731,7 +731,7 @@ module ietf-flexi-grid-topology {
         + "tet:label-step/tet:technology" {
     when "../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -750,7 +750,7 @@ module ietf-flexi-grid-topology {
         + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
     when "../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -770,7 +770,7 @@ module ietf-flexi-grid-topology {
         + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
     when "../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -793,7 +793,7 @@ module ietf-flexi-grid-topology {
         + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
     when "../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -816,7 +816,7 @@ module ietf-flexi-grid-topology {
         + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
     when "../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -837,7 +837,7 @@ module ietf-flexi-grid-topology {
         + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
     when "../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -858,7 +858,7 @@ module ietf-flexi-grid-topology {
         + "tet:label-start/tet:te-label/tet:technology" {
     when "../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -878,7 +878,7 @@ module ietf-flexi-grid-topology {
         + "tet:label-end/tet:te-label/tet:technology" {
     when "../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -899,7 +899,7 @@ module ietf-flexi-grid-topology {
         + "tet:label-step/tet:technology" {
     when "../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -919,7 +919,7 @@ module ietf-flexi-grid-topology {
         + "tet:label-start/tet:te-label/tet:technology" {
     when "../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -939,7 +939,7 @@ module ietf-flexi-grid-topology {
         + "tet:label-end/tet:te-label/tet:technology" {
     when "../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -959,7 +959,7 @@ module ietf-flexi-grid-topology {
         + "tet:label-step/tet:technology" {
     when "../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -979,7 +979,7 @@ module ietf-flexi-grid-topology {
         + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
     when "../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -999,7 +999,7 @@ module ietf-flexi-grid-topology {
         + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
     when "../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1022,7 +1022,7 @@ module ietf-flexi-grid-topology {
         + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
     when "../../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1046,7 +1046,7 @@ module ietf-flexi-grid-topology {
         + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
     when "../../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1068,7 +1068,7 @@ module ietf-flexi-grid-topology {
         + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
     when "../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1089,7 +1089,7 @@ module ietf-flexi-grid-topology {
       + "tet:te-label/tet:technology" {
     when "../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1110,7 +1110,7 @@ module ietf-flexi-grid-topology {
         + "tet:te-label/tet:technology"{
     when "../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1131,7 +1131,7 @@ module ietf-flexi-grid-topology {
         + "tet:technology"{
     when "../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1151,7 +1151,7 @@ module ietf-flexi-grid-topology {
         + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
     when "../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1171,7 +1171,7 @@ module ietf-flexi-grid-topology {
         + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
     when "../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1194,7 +1194,7 @@ module ietf-flexi-grid-topology {
         + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
     when "../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1218,7 +1218,7 @@ module ietf-flexi-grid-topology {
         + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
     when "../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1240,7 +1240,7 @@ module ietf-flexi-grid-topology {
         + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
     when "../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1261,7 +1261,7 @@ module ietf-flexi-grid-topology {
         + "tet:label-start/tet:te-label/tet:technology" {
     when "../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1282,7 +1282,7 @@ module ietf-flexi-grid-topology {
         + "tet:label-end/tet:te-label/tet:technology" {
     when "../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1303,7 +1303,7 @@ module ietf-flexi-grid-topology {
         + "tet:label-step/tet:technology" {
     when "../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1324,7 +1324,7 @@ module ietf-flexi-grid-topology {
         + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
     when "../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1345,7 +1345,7 @@ module ietf-flexi-grid-topology {
         + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
     when "../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1369,7 +1369,7 @@ module ietf-flexi-grid-topology {
         + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
     when "../../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1394,7 +1394,7 @@ module ietf-flexi-grid-topology {
         + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
     when "../../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1417,7 +1417,7 @@ module ietf-flexi-grid-topology {
         + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
     when "../../../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1435,7 +1435,7 @@ module ietf-flexi-grid-topology {
         + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
     when "../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1454,7 +1454,7 @@ module ietf-flexi-grid-topology {
         + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
     when "../../../../../../../../"
        + "nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1472,7 +1472,7 @@ module ietf-flexi-grid-topology {
         + "tet:label-restrictions/tet:label-restriction/"
         + "tet:label-start/tet:te-label/tet:technology" {
     when "../../../../../../../nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1489,7 +1489,7 @@ module ietf-flexi-grid-topology {
         + "tet:label-restrictions/tet:label-restriction/"
         + "tet:label-end/tet:te-label/tet:technology" {
     when "../../../../../../../nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1506,7 +1506,7 @@ module ietf-flexi-grid-topology {
         + "tet:label-restrictions/tet:label-restriction/"
         + "tet:label-step/tet:technology" {
     when "../../../../../../nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1523,7 +1523,7 @@ module ietf-flexi-grid-topology {
         + "tet:label-restrictions/tet:label-restriction/"
         + "tet:label-start/tet:te-label/tet:technology" {
     when "../../../../../../../nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1541,7 +1541,7 @@ module ietf-flexi-grid-topology {
         + "tet:label-restrictions/tet:label-restriction/"
         + "tet:label-end/tet:te-label/tet:technology" {
     when "../../../../../../../nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";
@@ -1559,7 +1559,7 @@ module ietf-flexi-grid-topology {
         + "tet:label-restrictions/tet:label-restriction/"
         + "tet:label-step/tet:technology" {
     when "../../../../../../nw:network-types/tet:te-topology/"
-       + "flexi-grid:flexi-grid-topology" {
+       + "tet-flexig:flexi-grid-topology" {
       description
         "Augmentation parameters apply only for networks with
          Flexi-grid topology type.";

--- a/ietf-flexi-grid-topology.yang
+++ b/ietf-flexi-grid-topology.yang
@@ -38,7 +38,7 @@ module ietf-flexi-grid-topology {
      WG List: <mailto:ccamp@ietf.org>
 
      Editor: Jorge E. Lopez de Vergara  
-             <mailtojorge.lopez_vergara@uam.es>
+             <mailto:jorge.lopez_vergara@uam.es>
 
      Editor: Daniel Perdices 
              <mailto:daniel.perdices@naudit.es>
@@ -53,7 +53,12 @@ module ietf-flexi-grid-topology {
              <mailto:younglee.tx@gmail.com>";
 
   description
-    "This module defines a model for flexi-grid topology.
+    "This module provides a YANG data model for the routing and
+     wavelength assignment (RWA) Traffic Engineering (TE)
+     topology in Flexi-grid optical networks. The YANG model 
+     described in this document is a Flexi-grid technology-specific
+     YANG model augmenting the generic TE topology module 
+     (ietf-te-topology, RFC 9795) based on the RFC 7698.
 
      Copyright (c) 2020 IETF Trust and the persons identified
      as authors of the code.  All rights reserved.
@@ -72,7 +77,7 @@ module ietf-flexi-grid-topology {
     description
       "Initial Version";
     reference
-      "RFC XXXX: A Yang Data Model for flexi-grid Optical Networks";
+      "RFC XXXX: A YANG Data Model for Flexi-grid Optical Networks";
     // RFC Ed.: replace XXXX with actual RFC number, update date
     // information and remove this note
   }
@@ -104,7 +109,7 @@ module ietf-flexi-grid-topology {
     description "Augment TE node attributes.";
     container flexi-grid-node {
       presence "The TE node is a Flexi-grid node.";
-      description "Flexi-grid node attributes";
+      description "Flexi-grid node attributes.";
     }
   }
 
@@ -138,8 +143,8 @@ module ietf-flexi-grid-topology {
          Flexi-grid topology type.";
     }
     description
-      "Augment TE label range information for the source LTP
-       of the connectivity matrix entry.";
+      "Augment TE label range information for the source Link
+       Termination Point (LTP) of the connectivity matrix entry.";
     uses l0-types:flexi-grid-label-range-info;
   }
 
@@ -218,8 +223,8 @@ module ietf-flexi-grid-topology {
          Flexi-grid topology type.";
     }
     description
-      "Augment TE label range information for the TTP
-       Local Link Connectivities.";
+      "Augment TE label range information for the Tunnel 
+      Termination Point (TTP) Local Link Connectivities.";
     uses l0-types:flexi-grid-label-range-info;
   }
 
@@ -294,7 +299,7 @@ module ietf-flexi-grid-topology {
     }
     description
       "Augment TE label range start for the TE node
-       connectivity matrices";
+       connectivity matrices.";
     case flexi-grid {
       uses l0-types:flexi-grid-label-start-end;
     }
@@ -313,7 +318,7 @@ module ietf-flexi-grid-topology {
     }
     description
       "Augment TE label range end for the TE node
-       connectivity matrices";
+       connectivity matrices.";
     case flexi-grid {
       uses l0-types:flexi-grid-label-start-end;
     }
@@ -332,7 +337,7 @@ module ietf-flexi-grid-topology {
     }
     description
       "Augment TE label range step for the TE node
-       connectivity matrices";
+       connectivity matrices.";
     case flexi-grid {
       uses l0-types:flexi-grid-label-step;
     }
@@ -352,7 +357,7 @@ module ietf-flexi-grid-topology {
     }
     description
       "Augment TE label hop for the underlay primary path of the
-       TE node connectivity matrices";
+       TE node connectivity matrices.";
     case flexi-grid {
       uses l0-types:flexi-grid-label-hop;
     }
@@ -372,7 +377,7 @@ module ietf-flexi-grid-topology {
     }
     description
       "Augment TE label hop for the underlay backup path of the
-       TE node connectivity matrices";
+       TE node connectivity matrices.";
     case flexi-grid {
       uses l0-types:flexi-grid-label-hop;
     }
@@ -396,7 +401,7 @@ module ietf-flexi-grid-topology {
     description
       "Augment TE label hop for the explicit route objects excluded
        by the path computation of the TE node connectivity
-       matrices";
+       matrices.";
     case flexi-grid {
       uses l0-types:flexi-grid-label-hop;
     }
@@ -420,7 +425,7 @@ module ietf-flexi-grid-topology {
     description
       "Augment TE label hop for the explicit route objects included
        by the path computation of the TE node connectivity
-       matrices";
+       matrices.";
     case flexi-grid {
       uses l0-types:flexi-grid-label-hop;
     }
@@ -440,7 +445,7 @@ module ietf-flexi-grid-topology {
     }
     description
       "Augment TE label hop for the computed path route objects
-       of the TE node connectivity matrices";
+       of the TE node connectivity matrices.";
     case flexi-grid {
       uses l0-types:flexi-grid-label-hop;
     }


### PR DESCRIPTION
While checking RFC 8407 (YANG Guidelines) and YANGDOCTORS reviews of draft-ietf-ccamp-layer0-types and draft-ietf-ccamp-wson-yang, I found some minor issues that can be easily fixed. Find next the changes we propose to fix them:

- In contact section, one of the mailto links was not a proper link.
- Description of the YANG module has been extended.
- Yang => YANG.
- Fixed some inconsistencies with the capitalization of Flexi-grid. Now, it is consistent with draft-ietf-ccamp-layer0-types.
- First occurrence of acronyms has been expanded.
- All descriptions end with a period/full stop.